### PR TITLE
- new transcripts/names/abstracts;

### DIFF
--- a/docs/_includes/footer.html
+++ b/docs/_includes/footer.html
@@ -29,7 +29,7 @@
       <div class="footer-col footer-col-2">
         <ul class="social-media-list">
           <li>
-            <a href="https://github.com/digitaljudaica/www.alter-rebbe.org">
+            <a href="https://github.com/digitaljudaica/alter-rebbe.org">
               <svg class="svg-icon"><use xlink:href="/assets/minima-social-icons.svg#github"></use></svg>
               <span class="username">repository</span>
             </a>

--- a/docs/collections/names.xml
+++ b/docs/collections/names.xml
@@ -226,6 +226,10 @@
           </p>
           <p>сын Зелмана Янкелевича</p>
         </person>
+        <person xml:id="Елиашевич_Федор_Петрович">
+          <persName>Елиашевич_Федор_Петрович</persName>
+          <p rendition="mentions"> </p>
+        </person>
         <person xml:id="Ицко_Саіович">
           <persName>Ицко Саіович</persName>
           <p rendition="mentions">
@@ -237,6 +241,12 @@
           <persName>Ицка</persName>
           <p rendition="mentions">
             <ref target="/collections/rgada/documents/099.html" role="documentViewer">099</ref>
+          </p>
+        </person>
+        <person xml:id="Ицка_Мелентович">
+          <persName>Ицка Мелентович</persName>
+          <p rendition="mentions">
+            <ref target="/collections/rgia413/documents/032.html" role="documentViewer">032</ref>
           </p>
         </person>
         <person xml:id="Јосель_Мовшович">
@@ -422,6 +432,7 @@
             <ref target="/collections/rgada/documents/097.html" role="documentViewer">097</ref>
             <ref target="/collections/rgada/documents/101.html" role="documentViewer">101</ref>
             <ref target="/collections/rgada/documents/152a.html" role="documentViewer">152a</ref>
+            <ref target="/collections/rgia413/documents/030.html" role="documentViewer">030</ref>
           </p>
           <p>Состоит в родстве с Рафаловичем.</p>
         </person>
@@ -966,6 +977,7 @@
             <ref target="/collections/rgada/documents/090.html" role="documentViewer">090</ref>
             <ref target="/collections/rgada/documents/099.html" role="documentViewer">099</ref>
             <ref target="/collections/rgia413/documents/008.html" role="documentViewer">008</ref>
+            <ref target="/collections/rgia413/documents/030.html" role="documentViewer">030</ref>
             <ref target="/collections/rgia413/documents/032.html" role="documentViewer">032</ref>
           </p>
         </org>
@@ -985,6 +997,7 @@
           <orgName>Литовское губернское правление</orgName>
           <p rendition="mentions">
             <ref target="/collections/rgada/documents/097.html" role="documentViewer">097</ref>
+            <ref target="/collections/rgia413/documents/030.html" role="documentViewer">030</ref>
           </p>
         </org>
         <org xml:id="Тайная_экспедиция">
@@ -1197,18 +1210,6 @@
             <ref target="/collections/rgia413/documents/032.html" role="documentViewer">032</ref>
           </p>
         </person>
-        <person xml:id="Ицка_Мелентович">
-          <persName>Ицка Мелентович</persName>
-          <p rendition="mentions">
-          <ref target="/collections/rgia413/documents/032.html" role="documentViewer">032</ref>
-          </p>
-        </person>
-        <person xml:id="Елиашевич_Федор_Петрович">
-        <persName> Елиашевич_Федор_Петрович </persName>
-        <p rendition="mentions">
-        <ref target="/collections/rgia413/documents/027.html" role="documentViewer">027</ref>
-        </p>
-  </person>
       </listPerson>
     </body>
   </text>

--- a/docs/collections/rgia413/tei/030.xml
+++ b/docs/collections/rgia413/tei/030.xml
@@ -1,4 +1,3 @@
-
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/tei_all.rng" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0">

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -8,7 +8,7 @@ layout: page
 ## Подача материала ##
 
 Содержимое сайта находится в GitHub repository
-[https://github.com/digitaljudaica/www.alter-rebbe.org](https://github.com/digitaljudaica/www.alter-rebbe.org).
+[https://github.com/digitaljudaica/alter-rebbe.org](https://github.com/digitaljudaica/alter-rebbe.org).
 
 Рекомендуемый способ участия в расшифровке, исправлении ошибок и т.д. - открыть GitHub pull request.
 Если прогресс (пока) не пришёл в Ваш дом, и термины GitHub, repository и pull request Вам ничего не

--- a/src/main/scala/org/podval/archive19kislev/collector/Xml.scala
+++ b/src/main/scala/org/podval/archive19kislev/collector/Xml.scala
@@ -6,8 +6,12 @@ import scala.xml.{Elem, Node, PrettyPrinter, Text, TopScope, Utility, XML}
 
 object Xml {
 
-  def load(file: File): Elem =
+  def load(file: File): Elem = try {
     Utility.trimProper(XML.loadFile(file)).asInstanceOf[Elem]
+  } catch {
+    case e: org.xml.sax.SAXParseException =>
+      throw new IllegalArgumentException(s"In file $file:", e)
+  }
 
   def contentOf(element: Option[Elem]): Seq[Node] =
     element.fold[Seq[Node]](Text(""))(_.child.map(removeNamespace))


### PR DESCRIPTION
- cleanup and slightly better error reporting;
- renamed repository from `www.alter-rebbe.org` to `alter-rebbe.org`;